### PR TITLE
Added Basepath to Auth routes, <RedirectToSignIn/>, redirectToSignIn()

### DIFF
--- a/jest-edge.config.js
+++ b/jest-edge.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '**/tests/handlers/**/*.app-router.test.ts',
     '**/tests/handlers/middleware/middleware.test.ts',
     '**/tests/server-functions/**/*.app-router.test.ts',
+    '**/tests/config/**/*.app-router.test.ts',
     '**/tests/utils.test.ts',
   ],
   moduleNameMapper: { '^uuid$': 'uuid' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monocloud/nextjs-auth",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@monocloud/nextjs-auth",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@monocloud/node-auth-core": "0.1.2",
@@ -1574,126 +1574,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
-      "integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
-      "integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
-      "integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
-      "integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
-      "integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
-      "integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
-      "integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.4.tgz",
-      "integrity": "sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monocloud/nextjs-auth",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "MonoCloud Next.js Authentication SDK",
   "keywords": [
     "monocloud",
@@ -42,7 +42,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@monocloud/node-auth-core": "0.1.2",
+    "@monocloud/node-auth-core": "0.1.3",
     "cookie": "^0.6.0",
     "next": "^14.2.4",
     "react": "^18.3.1",

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -3,3 +3,4 @@ export { SignIn } from './signin';
 export { SignUp } from './signup';
 export { SignOut } from './signout';
 export { protectPage } from './protect';
+export { RedirectToSignIn } from './redirect-to-signin';

--- a/src/client/monocloud-auth-provider.tsx
+++ b/src/client/monocloud-auth-provider.tsx
@@ -25,12 +25,31 @@ const initialState: AuthState = {
   error: undefined,
 };
 
-const MonoCloudAuthContext = createContext<AuthState>({ ...initialState });
+const MonoCloudAuthContext = createContext<AuthState>(
+  undefined as unknown as AuthState
+);
 
-export const useUser = () => useContext(MonoCloudAuthContext);
+export const useUser = () => {
+  const ctx = useContext(MonoCloudAuthContext);
+
+  if (!ctx) {
+    throw new Error(
+      `useUser() can only be used inside <MonoCloudAuthProvider>...</MonoCloudAuthProvider>. To setup MonoCloud Auth Provider visit any of the following links.
+        App Router - https://www.monocloud.com/docs/sdk-reference/nextjs/app-router/getting-started.
+        Router - https://www.monocloud.com/docs/sdk-reference/nextjs/page-router/getting-started.
+      `
+    );
+  }
+
+  return ctx;
+};
 
 const fetchUser = async (): Promise<MonoCloudUser | undefined> => {
-  const response = await fetch('/api/auth/userinfo');
+  const response = await fetch(
+    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_USER_INFO_URL ??
+      // eslint-disable-next-line no-underscore-dangle
+      `${process.env.__NEXT_ROUTER_BASEPATH ?? ''}/api/auth/userinfo`
+  );
 
   if (response.status === 204) {
     return undefined;

--- a/src/client/protect.tsx
+++ b/src/client/protect.tsx
@@ -31,12 +31,14 @@ type ProtectPage = <P extends {}>(
   options?: ProtectPageOptions
 ) => React.FC<P>;
 
-const redirectToSignIn = (returnUrl?: string) => {
-  const location = window.location.toString();
+export const redirectToSignIn = (returnUrl?: string) => {
   const encodedReturnUrl = encodeURIComponent(
-    returnUrl ?? (location.replace(new URL(location).origin, '') || '/')
+    returnUrl ?? window.location.toString()
   );
-  window.location.assign(`/api/auth/signin?return_url=${encodedReturnUrl}`);
+  window.location.assign(
+    // eslint-disable-next-line no-underscore-dangle
+    `${process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_IN_URL ?? `${process.env.__NEXT_ROUTER_BASEPATH ?? ''}/api/auth/signin`}?return_url=${encodedReturnUrl}`
+  );
 };
 
 /* c8 ignore start */

--- a/src/client/redirect-to-signin.tsx
+++ b/src/client/redirect-to-signin.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+/* eslint-disable @typescript-eslint/no-redeclare */
+/* eslint-disable react/jsx-no-useless-fragment */
+
+import { type FunctionComponent, useEffect } from 'react';
+import { redirectToSignIn } from './protect';
+import type { RedirectToSignInProps } from '../types';
+
+/**
+ * A client side component that will redirect users to the sign in page.
+ *
+ * @type RedirectToSignInProps
+ */
+export const RedirectToSignIn: FunctionComponent<RedirectToSignInProps> = ({
+  returnUrl,
+}) => {
+  useEffect(() => {
+    redirectToSignIn(returnUrl);
+  }, [returnUrl]);
+  return null;
+};

--- a/src/client/signin.tsx
+++ b/src/client/signin.tsx
@@ -17,7 +17,9 @@ export const SignIn: React.FC<SignInProps> = ({
   ...props
 }) => {
   const signInUrl =
-    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_IN_URL ?? '/api/auth/signin';
+    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_IN_URL ??
+    // eslint-disable-next-line no-underscore-dangle
+    `${process.env.__NEXT_ROUTER_BASEPATH ?? ''}/api/auth/signin`;
 
   const query = new URLSearchParams();
 

--- a/src/client/signout.tsx
+++ b/src/client/signout.tsx
@@ -12,7 +12,9 @@ export const SignOut: React.FC<SignOutProps> = ({
   ...props
 }) => {
   const signOutUrl =
-    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_OUT_URL ?? '/api/auth/signout';
+    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_OUT_URL ??
+    // eslint-disable-next-line no-underscore-dangle
+    `${process.env.__NEXT_ROUTER_BASEPATH ?? ''}/api/auth/signout`;
 
   const query = new URLSearchParams();
 

--- a/src/client/signup.tsx
+++ b/src/client/signup.tsx
@@ -12,7 +12,9 @@ export const SignUp: React.FC<SignUpProps> = ({
   ...props
 }) => {
   const signInUrl =
-    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_IN_URL ?? '/api/auth/signin';
+    process.env.NEXT_PUBLIC_MONOCLOUD_AUTH_SIGN_IN_URL ??
+    // eslint-disable-next-line no-underscore-dangle
+    `${process.env.__NEXT_ROUTER_BASEPATH ?? ''}/api/auth/signin`;
 
   const query = new URLSearchParams();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,5 @@ export {
   isAuthenticated,
   protectApi,
   protectPage,
+  redirectToSignIn,
 } from './instance/initialize';

--- a/src/instance/initialize.ts
+++ b/src/instance/initialize.ts
@@ -10,6 +10,7 @@ import {
   MonoCloudMiddleware,
   ProtectApi,
   ProtectPage,
+  RedirectToSignIn,
 } from '../types';
 
 let instance: MonoCloudInstance;
@@ -65,6 +66,13 @@ export const isAuthenticated: BaseFuncHandler<boolean> = (...args: unknown[]) =>
   getInstance().isAuthenticated(
     ...(args as Parameters<BaseFuncHandler<boolean>>)
   );
+
+/**
+ * Redirects the user to sign-in if not authenticated.
+ * **Note: This function only works on App Router.**
+ */
+export const redirectToSignIn: RedirectToSignIn = (returnUrl?: string) =>
+  getInstance().redirectToSignIn(returnUrl);
 
 /**
  * Protects an API handler.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -346,3 +346,20 @@ type ProtectApiApp = (
  * Protects an api route handler.
  */
 export type ProtectApi = ProtectApiApp & ProtectApiPage;
+
+/**
+ * Redirects user to sign in page.
+ *
+ * @param returnUrl - The url user will be redirected to after the sign in.
+ */
+export type RedirectToSignIn = (returnUrl?: string) => Promise<void>;
+
+/**
+ * Props for the `<RedirectToSignIn />` Component
+ */
+export interface RedirectToSignInProps {
+  /**
+   * The url user will be redirected to after the sign in.
+   */
+  returnUrl?: string;
+}

--- a/tests/client/protect-page.test.tsx
+++ b/tests/client/protect-page.test.tsx
@@ -40,7 +40,7 @@ describe('protectPage() - CSR', () => {
 
     await waitFor(() => {
       expect(window.location.assign).toHaveBeenCalledWith(
-        '/api/auth/signin?return_url=%2F'
+        '/api/auth/signin?return_url=https%3A%2F%2Fexample.org'
       );
       expect(container.textContent).not.toContain('Great Success!!!');
     });

--- a/tests/client/use-redirect-to-signin.test.tsx
+++ b/tests/client/use-redirect-to-signin.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable import/no-extraneous-dependencies */
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { fetchNoContent, wrapper } from '../client-helper';
+import { RedirectToSignIn, useUser } from '../../src/client';
+
+export const Component = () => {
+  const { user } = useUser();
+  if (!user) {
+    return <RedirectToSignIn />;
+  }
+  return <p>Great Success!!!</p>;
+};
+
+describe('<RedirectToSignIn/>', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        assign: jest.fn(),
+        toString: () => 'https://example.org',
+      },
+    });
+  });
+
+  it('should redirect to the sign in endpoint', async () => {
+    const ogFetch = global.fetch;
+
+    fetchNoContent();
+
+    const { container } = render(<Component />, { wrapper });
+
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalledWith(
+        '/api/auth/signin?return_url=https%3A%2F%2Fexample.org'
+      );
+      expect(container.textContent).not.toContain('Great Success!!!');
+    });
+
+    global.fetch = ogFetch;
+  });
+});

--- a/tests/client/use-user.test.tsx
+++ b/tests/client/use-user.test.tsx
@@ -15,14 +15,14 @@ describe('useUser()', () => {
   });
 
   it('should return the default value if MonoCloudAuthProvider is not setup', () => {
-    const { result } = renderHook(() => useUser());
-
-    expect(result.current).toEqual({
-      isAuthenticated: false,
-      isLoading: true,
-      user: undefined,
-      error: undefined,
-    });
+    try {
+      renderHook(() => useUser());
+      throw new Error();
+    } catch (error) {
+      expect(error.message).toContain(
+        'useUser() can only be used inside <MonoCloudAuthProvider>...</MonoCloudAuthProvider>.'
+      );
+    }
   });
 
   it('should return error if the server responded with an error', async () => {

--- a/tests/config/config.app-router.test.ts
+++ b/tests/config/config.app-router.test.ts
@@ -1,0 +1,164 @@
+import { NextRequest } from 'next/server';
+import { monoCloudAuth } from '../../src';
+import { setupOp, tokenAndUserInfoEnabled } from '../op-helpers';
+import {
+  TestAppRes,
+  defaultStateCookieValue,
+  setSessionCookie,
+  setStateCookie,
+} from '../common-helper';
+
+describe('Base Path', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let authHandler: any;
+
+  beforeEach(() => {
+    process.env.MONOCLOUD_AUTH_APP_URL = 'https://example.org/basepath';
+    authHandler = monoCloudAuth();
+  });
+
+  afterEach(() => {
+    process.env.MONOCLOUD_AUTH_APP_URL = undefined;
+  });
+
+  test('should have the base path in redirect uri', async () => {
+    setupOp();
+
+    const serverResponse = await authHandler(
+      new NextRequest(new URL('http://localhost:3000/api/auth/signin')),
+      {}
+    );
+
+    const res = new TestAppRes(serverResponse);
+
+    expect(res.status).toBe(302);
+    expect(res.locationHeader.query.redirect_uri).toBe(
+      'https://example.org/basepath/api/auth/callback'
+    );
+  });
+
+  it('should redirect to app url with base path after callback', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/auth/callback?state=state&nonce=nonce&code=code'
+    );
+
+    await setStateCookie(req);
+
+    const response = await authHandler(req);
+
+    const res = new TestAppRes(response);
+
+    expect(res.locationHeaderPathOnly).toBe('https://example.org/basepath');
+  });
+
+  it('should have base path in return url when set through query from signin after callback', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    const req = new NextRequest(
+      `http://localhost:3000/api/auth/callback?state=state&nonce=state&code=code`
+    );
+
+    await setStateCookie(req, '', {
+      ...defaultStateCookieValue,
+      returnUrl: encodeURIComponent('/custom'),
+    });
+
+    const response = await authHandler(req);
+
+    const res = new TestAppRes(response);
+
+    expect(res.locationHeaderPathOnly).toBe(
+      'https://example.org/basepath/custom'
+    );
+  });
+
+  it('should remove the session and redirect to authorization server (with base path in post logout uri)', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    const req = new NextRequest('http://localhost:3000/api/auth/signout');
+
+    await setSessionCookie(req);
+
+    const response = await authHandler(req);
+
+    const res = new TestAppRes(response);
+
+    expect(res.locationHeaderPathOnly).toBe(
+      'https://op.example.com/endsession'
+    );
+    expect(res.locationHeader.query).toEqual({
+      post_logout_redirect_uri: 'https://example.org/basepath',
+      id_token_hint: 'idtoken',
+      client_id: '__test_client_id__',
+    });
+    expect(res.sessionCookie.value).toBeUndefined();
+    expect(res.sessionCookie.options.expires).toEqual(new Date(0));
+  });
+
+  ['/something', 'https://example.org/basepath/something'].forEach(url => {
+    it('should assign the post_logout_redirect_uri from the query (with base path)', async () => {
+      await setupOp(
+        undefined,
+        tokenAndUserInfoEnabled,
+        {},
+        'https://example.org/basepath/api/auth/callback'
+      );
+
+      const req = new NextRequest(
+        `http://localhost:3000/api/auth/signout?post_logout_url=${url}`
+      );
+
+      await setSessionCookie(req);
+
+      const response = await authHandler(req);
+
+      const res = new TestAppRes(response);
+
+      expect(res.locationHeaderPathOnly).toBe(
+        'https://op.example.com/endsession'
+      );
+      expect(res.locationHeader.query).toEqual({
+        post_logout_redirect_uri: 'https://example.org/basepath/something',
+        id_token_hint: 'idtoken',
+        client_id: '__test_client_id__',
+      });
+      expect(res.sessionCookie.value).toBeUndefined();
+      expect(res.sessionCookie.options.expires).toEqual(new Date(0));
+    });
+  });
+
+  it('should redirect to app url with base path if there is no session', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    const req = new NextRequest('http://localhost:3000/api/auth/signout');
+
+    const response = await authHandler(req);
+
+    const res = new TestAppRes(response);
+
+    expect(res.locationHeaderPathOnly).toBe('https://example.org/basepath');
+    expect(res.sessionCookie.value).toBeUndefined();
+  });
+});

--- a/tests/config/config.page-router.test.ts
+++ b/tests/config/config.page-router.test.ts
@@ -1,0 +1,146 @@
+import { CookieJar } from 'tough-cookie';
+import { monoCloudAuth } from '../../src';
+import {
+  defaultDiscovery,
+  noTokenAndUserInfo,
+  setupOp,
+  tokenAndUserInfoEnabled,
+} from '../op-helpers';
+import { get, startNodeServer, stopNodeServer } from '../page-router-helpers';
+import {
+  defaultStateCookieValue,
+  setSessionCookie,
+  setStateCookie,
+} from '../common-helper';
+
+describe('Base Path', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let authHandler: any;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    process.env.MONOCLOUD_AUTH_APP_URL = 'https://example.org/basepath';
+
+    authHandler = monoCloudAuth();
+    baseUrl = await startNodeServer(authHandler);
+  });
+
+  afterEach(async () => {
+    authHandler = undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    baseUrl = undefined as any;
+    await stopNodeServer();
+    process.env.MONOCLOUD_AUTH_APP_URL = undefined;
+  });
+
+  it('should have the base path in redirect uri', async () => {
+    setupOp(defaultDiscovery, noTokenAndUserInfo);
+
+    const res = await get(baseUrl, '/api/auth/signin');
+
+    expect(res.status).toBe(302);
+    expect(res.locationHeader.query.redirect_uri).toBe(
+      'https://example.org/basepath/api/auth/callback'
+    );
+  });
+
+  it('should redirect to app url with base path after callback', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    baseUrl = await startNodeServer(authHandler);
+    const path = '/api/auth/callback?state=state&nonce=nonce&code=code';
+
+    const cookieJar = new CookieJar();
+
+    await setStateCookie(cookieJar, `${baseUrl}${path}`);
+
+    const res = await get(baseUrl, path, cookieJar);
+
+    expect(res.locationHeaderPathOnly).toBe('https://example.org/basepath');
+
+    await stopNodeServer();
+  });
+
+  it('should have base path in return url when set through query from signin after callback', async () => {
+    await setupOp(
+      undefined,
+      tokenAndUserInfoEnabled,
+      {},
+      'https://example.org/basepath/api/auth/callback'
+    );
+
+    baseUrl = await startNodeServer(authHandler);
+    const path = '/api/auth/callback?state=state&nonce=nonce&code=code';
+
+    const cookieJar = new CookieJar();
+
+    await setStateCookie(cookieJar, `${baseUrl}${path}`, {
+      ...defaultStateCookieValue,
+      returnUrl: encodeURIComponent('/custom'),
+    });
+
+    const res = await get(baseUrl, path, cookieJar);
+
+    expect(res.locationHeaderPathOnly).toBe(
+      'https://example.org/basepath/custom'
+    );
+  });
+
+  it('should remove the session and redirect to authorization server (with base path in post logout uri)', async () => {
+    const path = '/api/auth/signout';
+
+    const cookieJar = new CookieJar();
+
+    await setSessionCookie(cookieJar, `${baseUrl}${path}`);
+
+    const res = await get(baseUrl, path, cookieJar);
+
+    expect(res.locationHeaderPathOnly).toBe(
+      'https://op.example.com/endsession'
+    );
+    expect(res.locationHeader.query).toEqual({
+      post_logout_redirect_uri: 'https://example.org/basepath',
+      id_token_hint: 'idtoken',
+      client_id: '__test_client_id__',
+    });
+    expect(res.sessionCookie.value).toBeUndefined();
+    expect(res.sessionCookie.options.expires).toEqual(new Date(0));
+  });
+
+  ['/something', 'https://example.org/basepath/something'].forEach(url => {
+    it('should assign the post_logout_redirect_uri from the query', async () => {
+      const path = `/api/auth/signout?post_logout_url=${url}`;
+
+      const cookieJar = new CookieJar();
+
+      await setSessionCookie(cookieJar, `${baseUrl}${path}`);
+
+      const res = await get(baseUrl, path, cookieJar);
+
+      expect(res.locationHeaderPathOnly).toBe(
+        'https://op.example.com/endsession'
+      );
+      expect(res.locationHeader.query).toEqual({
+        post_logout_redirect_uri: 'https://example.org/basepath/something',
+        id_token_hint: 'idtoken',
+        client_id: '__test_client_id__',
+      });
+      expect(res.sessionCookie.value).toBeUndefined();
+      expect(res.sessionCookie.options.expires).toEqual(new Date(0));
+    });
+  });
+
+  it('should redirect to app url if there is no session', async () => {
+    const path = '/api/auth/signout';
+
+    const res = await get(baseUrl, path);
+
+    expect(res.locationHeaderPathOnly).toBe('https://example.org/basepath');
+    expect(res.sessionCookie.value).toBeUndefined();
+  });
+});

--- a/tests/handlers/signin/signin.app-router.test.ts
+++ b/tests/handlers/signin/signin.app-router.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../op-helpers';
 
 describe('SignIn Handler - App Router', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let authHandler: any;
 
   beforeEach(() => {

--- a/tests/op-helpers.ts
+++ b/tests/op-helpers.ts
@@ -33,7 +33,8 @@ export const setupOp = async (
     token: boolean;
     userinfo: boolean;
   } = { token: true, userinfo: true },
-  customRefreshBodyMatcher = {}
+  customRefreshBodyMatcher = {},
+  redirectUri = 'https://example.org/api/auth/callback'
 ) => {
   nock('https://op.example.com')
     .get('/.well-known/openid-configuration')
@@ -87,7 +88,7 @@ export const setupOp = async (
       .post('/token', body => {
         return (
           body.code === 'code' &&
-          body.redirect_uri === 'https://example.org/api/auth/callback' &&
+          body.redirect_uri === redirectUri &&
           body.code_verifier?.trim().length > 0 &&
           body.grant_type === 'authorization_code'
         );

--- a/tests/server-functions/redirect-to-signin/redirect-to-signin.app-router.test.ts
+++ b/tests/server-functions/redirect-to-signin/redirect-to-signin.app-router.test.ts
@@ -1,0 +1,105 @@
+import React from 'react';
+import { NextRequest } from 'next/server';
+import { monoCloudAuth, redirectToSignIn } from '../../../src';
+import { setSessionCookie } from '../../common-helper';
+
+const Component = async () => {
+  await redirectToSignIn();
+  return React.createElement('div', {}, 'Great Success!!!');
+};
+
+describe('redirectToSignIn() - App Router', () => {
+  let req: NextRequest;
+
+  beforeEach(() => {
+    req = new NextRequest('http://localhost:3000/');
+
+    monoCloudAuth();
+
+    jest.mock('next/headers', () => {
+      const headers = jest.requireActual('next/headers');
+      return {
+        ...headers,
+        headers: () => ({
+          ...headers.headers,
+          get: (name: string) => req.headers.get(name),
+        }),
+        cookies: () => ({
+          ...headers.cookies,
+          get: (name: string) => req.cookies.get(name),
+          getAll: () => req.cookies.getAll(),
+        }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    req = undefined as unknown as NextRequest;
+  });
+
+  it('should render the component when session exists', async () => {
+    await setSessionCookie(req);
+
+    const componentResult: JSX.Element = await Component();
+
+    expect(componentResult.type).toBe('div');
+    expect(componentResult.props.children).toBe('Great Success!!!');
+  });
+
+  it('should redirect to sign in when there is no session', async () => {
+    jest.mock('next/navigation', () => ({
+      redirect: (url: URL) => {
+        expect(url.toString()).toBe(
+          'https://example.org/api/auth/signin?return_url=%2F'
+        );
+      },
+    }));
+
+    try {
+      await Component();
+    } catch (error) {
+      expect(error.message).toBe('NEXT_REDIRECT');
+    }
+  });
+
+  it('should pickup return url from x-monocloud-path header', async () => {
+    req.headers.set('x-monocloud-path', '/custom');
+
+    jest.mock('next/navigation', () => ({
+      redirect: (url: URL) => {
+        expect(url.toString()).toBe(
+          'https://example.org/api/auth/signin?return_url=%2Fcustom'
+        );
+      },
+    }));
+
+    try {
+      await Component();
+    } catch (error) {
+      expect(error.message).toBe('NEXT_REDIRECT');
+    }
+  });
+
+  it('should pickup return url from options if configured', async () => {
+    req.headers.set('x-monocloud-path', '/custom');
+
+    jest.mock('next/navigation', () => ({
+      redirect: (url: URL) => {
+        expect(url.toString()).toBe(
+          'https://example.org/api/auth/signin?return_url=%2Foverrides'
+        );
+      },
+    }));
+
+    const ComponentWithRedirect = async () => {
+      await redirectToSignIn('/overrides');
+      return React.createElement('div', {}, 'Great Success!!!');
+    };
+
+    try {
+      await ComponentWithRedirect();
+    } catch (error) {
+      expect(error.message).toBe('NEXT_REDIRECT');
+    }
+  });
+});

--- a/tests/server-functions/redirect-to-signin/redirect-to-signin.page-router.test.ts
+++ b/tests/server-functions/redirect-to-signin/redirect-to-signin.page-router.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { monoCloudAuth, redirectToSignIn } from '../../../src';
+import {
+  get,
+  startNodeServer,
+  stopNodeServer,
+} from '../../page-router-helpers';
+
+describe('redirectToSignIn() - Page Router', () => {
+  it('should throw "redirectToSignIn() can only be used in App Router project"', async () => {
+    monoCloudAuth();
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const getServerSideProps = async (_context: any) => {
+      await redirectToSignIn();
+      return Promise.resolve({ props: { custom: 'prop' } });
+    };
+
+    const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+      try {
+        await getServerSideProps({
+          req,
+          res,
+          query: req.query,
+          resolvedUrl: req.url ?? '/',
+        });
+        throw new Error();
+      } catch (error) {
+        expect(error.message).toBe(
+          'redirectToSignIn() can only be used in App Router project'
+        );
+      }
+
+      res.end();
+    };
+
+    const baseUrl = await startNodeServer(handler);
+
+    await get(baseUrl, '/');
+
+    await stopNodeServer();
+  });
+});


### PR DESCRIPTION
- Added basepath to auth routes using __NEXT_ROUTER_BASEPATH
- Added <RedirectToSignIn /> client component which will redirect the user to sign in if rendered.
- Added redirectToSignIn() server side function which will redirect the user to sign in page if the request is authenticated. Works only in app router.
- Added Error when using useUser() without wrapping it in. <MonoCloudAuthProvider>.
- Removed use of new URL to join the queries.